### PR TITLE
droneloc: add extended kalman filter support

### DIFF
--- a/python_loc/config.py
+++ b/python_loc/config.py
@@ -20,8 +20,11 @@ UDP_PLOT_IP = '127.0.0.1'
 UDP_PLOT_PORT = 5558
 
 # Landing point in meters, middle of the landing platform
-LANDING_X = 0.60 / 2
-LANDING_Y = 0.60 / 2
+LANDING_X = 1.30 / 2
+LANDING_Y = 1.30 / 2
+# Drone coords are in NED, so landing angle should be North
+# oriented, clockwise
+LANDING_ANGLE = 0
 
 TESTING_STAND = 2
 

--- a/python_loc/config.py
+++ b/python_loc/config.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import enum
-from droneloc import kalman_type
 
 # Distances from DWM1001-server
 MCAST_GRP = '224.1.1.1'

--- a/python_loc/config.py
+++ b/python_loc/config.py
@@ -2,6 +2,9 @@
 
 import numpy as np
 import enum
+from droneloc import kalman_type
+
+KALMAN_TYPE = kalman_type.UKF6
 
 # Distances from DWM1001-server
 MCAST_GRP = '224.1.1.1'

--- a/python_loc/droneloc.py
+++ b/python_loc/droneloc.py
@@ -3,8 +3,7 @@
 """Drone localization
 
 Usage:
-  droneloc.py ekf --trajectory <file> [--post-smoother <smoother>] [--noise-std <sigma>] [--seed <seed>]
-  droneloc.py ukf --trajectory <file> [--post-smoother <smoother>] [--noise-std <sigma>] [--seed <seed>]
+  droneloc.py --trajectory <file> [--post-smoother <smoother>] [--noise-std <sigma>] [--seed <seed>]
 
 Options:
   -h --help                  Show this screen.
@@ -34,17 +33,10 @@ import filterpy.kalman
 import time
 import enum
 
-class kalman_type(enum.Enum):
-    EKF6   = 0
-    EKF9   = 1
-    UKF6   = 2
-
-
 class smoother_type(enum.Enum):
     SAVGOL   = 0
     UNIFORM  = 1
     GAUSSIAN = 2
-
 
 sigma_a = 0.125
 sigma_r = 0.2
@@ -81,27 +73,7 @@ anchors = [
 #       A - acceleration
 #
 
-def ekf_F_6(dt):
-    F = np.array([[1, dt,  0,  0,  0, 0],
-                  [0,  1,  0,  0,  0, 0],
-                  [0,  0,  1, dt,  0, 0],
-                  [0,  0,  0,  1,  0, 0],
-                  [0,  0,  0,  0,  1, dt],
-                  [0,  0,  0,  0,  0, 1]
-                  ])
-    return F
-
-
-def ekf_F_9(dt):
-    f = [[1, dt, -dt*dt/2.0],
-         [0, 1, -dt],
-         [0, 0, 1]]
-    F = block_diag(f, f, f)
-
-    return F
-
-
-def ukf_F_6(x, dt):
+def F_6(x, dt):
     F = np.array([[1, dt,  0,  0,  0, 0],
                   [0,  1,  0,  0,  0, 0],
                   [0,  0,  1, dt,  0, 0],
@@ -123,71 +95,6 @@ def Q_6(dt):
 
     return Q
 
-
-def Q_9(dt):
-    #Q = Q_discrete_white_noise(dim=2, dt=dt, var=sigma_a**2, block_size=3)
-
-    tao_acc = m_tao_acc_sqrt * m_tao_acc_sqrt
-    tao_bias = m_tao_bias_sqrt * m_tao_bias_sqrt
-
-    q = [[dt**3/3.0*tao_acc+dt**5/20.0*tao_bias,  dt**2/2*tao_acc+dt**4/8.0*tao_bias,  -dt**3/6*tao_bias],
-         [dt**2/2.0*tao_acc+dt**4/8.0*tao_bias ,  dt*tao_acc+dt**3/3*tao_bias,  -dt**2/2*tao_bias],
-         [-dt**3/6.0*tao_bias,  -dt**2/2*tao_bias,  dt*tao_bias]]
-    qz = np.array(q) * m_z_damping_factor
-    Q = block_diag(q, q, qz)
-    Q *= sigma_a**2
-    Q *= m_Q_scale
-
-    return Q
-
-
-def B_9(dt):
-    b = [[dt*dt/2.0,  0,  0],
-         [dt,  0,  0],
-         [0,  0,  0]]
-    B = block_diag(b, b, b)
-
-    return B
-
-
-def ekf_H_6(Xk, loc):
-    """ compute Jacobian of H matrix for state X """
-
-    H = np.empty([0, 6])
-    for anchor in loc['anchors']:
-        coords = anchor["pos"]["coords"]
-        anch_x = coords[0]
-        anch_y = coords[1]
-        anch_z = coords[2]
-
-        anch = np.array([anch_x, 0, anch_y, 0, anch_z, 0])
-        pos = np.array([Xk[0], 0, Xk[2], 0, Xk[4], 0])
-        r = np.linalg.norm(pos - anch) + 1e-6
-        h_row = (pos - anch) / r
-        H = np.append(H, [h_row], axis=0)
-
-    return H
-
-
-def ekf_H_9(Xk, loc):
-    """ compute Jacobian of H matrix for state X """
-
-    H = np.empty([0, 9])
-    for anchor in loc['anchors']:
-        coords = anchor["pos"]["coords"]
-        anch_x = coords[0]
-        anch_y = coords[1]
-        anch_z = coords[2]
-
-        anch = np.array([anch_x, 0, 0, anch_y, 0, 0, anch_z, 0, 0])
-        pos = np.array([Xk[0], 0, 0, Xk[3], 0, 0, Xk[6], 0, 0])
-        r = np.linalg.norm(pos - anch) + 1e-6
-        h_row = (pos - anch) / r
-        H = np.append(H, [h_row], axis=0)
-
-    return H
-
-
 def Hx_6(x, loc):
     """ takes a state X and returns the measurement that would
     correspond to that state.
@@ -207,27 +114,6 @@ def Hx_6(x, loc):
 
     return np.array(r_pred).T
 
-
-def Hx_9(x, loc):
-    """ takes a state X and returns the measurement that would
-    correspond to that state.
-    """
-
-    r_pred = []
-    for anchor in loc['anchors']:
-        coords = anchor["pos"]["coords"]
-        anch_x = coords[0]
-        anch_y = coords[1]
-        anch_z = coords[2]
-
-        anch = np.array([anch_x, anch_y, anch_z])
-        pos = np.array([x[0], x[3], x[6]])
-        r = np.linalg.norm(pos - anch) + 1e-6
-        r_pred.append(r)
-
-    return np.array(r_pred).T
-
-
 def get_measurements(loc):
     ranges = []
     for anchor in loc['anchors']:
@@ -237,40 +123,24 @@ def get_measurements(loc):
     return np.array(ranges).T
 
 
-def get_u(acc_data):
-    u = [acc_data["acc"][0], 0, 0,
-         acc_data["acc"][1], 0, 0,
-         acc_data["acc"][2], 0, 0]
-    return np.array(u).T
-
-
 class drone_localization():
-    kf_type = None
     kf = None
     dt = None
     process_ts = None
     post_smoother = None
     x_hist = []
 
-    def __init__(self, kf_type, dt=None, post_smoother=None):
-        if kf_type == kalman_type.EKF6:
-            kf = filterpy.kalman.ExtendedKalmanFilter(dim_x=6, dim_z=4)
-            kf.x = np.array([1, 0, 1, 0, 1, 0])
-        elif kf_type == kalman_type.EKF9:
-            kf = filterpy.kalman.ExtendedKalmanFilter(dim_x=9, dim_z=4, dim_u=9)
-            kf.x = np.array([1, 0, 0, 1, 0, 0, 1, 0, 0])
-        elif kf_type == kalman_type.UKF6:
-            points = filterpy.kalman.MerweScaledSigmaPoints(n=6, alpha=.1, beta=2, kappa=0)
-            kf = filterpy.kalman.UnscentedKalmanFilter(dim_x=6, dim_z=4, fx=ukf_F_6, hx=Hx_6,
-                                                       dt=dt, points=points)
-            kf.x = np.array([1, 0, 1, 0, 1, 0])
+    def __init__(self, dt=None, post_smoother=None):
+        points = filterpy.kalman.MerweScaledSigmaPoints(n=6, alpha=.1, beta=2, kappa=0)
+        kf = filterpy.kalman.UnscentedKalmanFilter(dim_x=6, dim_z=4, fx=F_6, hx=Hx_6,
+                                                   dt=dt, points=points)
+        kf.x = np.array([1, 0, 1, 0, 1, 0])
 
         # set cov of vel
         kf.P[1][1] = 0.1
         kf.P[3][3] = 0.1
         kf.P[5][5] = 0.1
 
-        self.kf_type = kf_type
         self.kf = kf
         self.dt = dt
         self.post_smoother = post_smoother
@@ -288,38 +158,19 @@ class drone_localization():
         return dt
 
 
-    def kf_process(self, loc, acc_data=None):
+    def kf_process(self, loc):
         old_x = self.kf.x
         old_P = self.kf.P
         R = np.eye(len(loc["anchors"])) * (sigma_r**2 * m_R_scale)
         dt = self.get_dt(loc)
 
-        if self.kf_type == kalman_type.EKF6:
-            self.kf.F = ekf_F_6(dt)
-        elif self.kf_type == kalman_type.EKF9:
-            self.kf.F = ekf_F_9(dt)
-            self.kf.B = B_9(dt)
         self.kf.Q = Q_6(dt)
         self.kf.dim_z = len(loc['anchors'])
-
-        if self.kf_type == kalman_type.EKF9:
-            u = get_u(acc_data)
-            self.kf.predict(u=u)
-        if self.kf_type == kalman_type.UKF6:
-            self.kf.predict(dt=dt)
-        else:
-            self.kf.predict()
+        self.kf.predict(dt=dt)
 
         z = get_measurements(loc)
-
         self.kf.R = R
-
-        if self.kf_type == kalman_type.EKF6:
-            self.kf.update(z, HJacobian=ekf_H_6, Hx=Hx_6, args=loc, hx_args=loc)
-        elif self.kf_type == kalman_type.EKF9:
-            self.kf.update(z, HJacobian=ekf_H_9, Hx=Hx_9, args=loc, hx_args=loc)
-        elif self.kf_type == kalman_type.UKF6:
-            self.kf.update(z, loc=loc)
+        self.kf.update(z, loc=loc)
 
         if np.any(np.abs(self.kf.y) > 2):
             print("innovation is too large: ", self.kf.y)
@@ -362,11 +213,6 @@ if __name__ == '__main__':
     args = docopt(__doc__)
     data_file = open(args['--trajectory'], 'r')
 
-    if args['ekf']:
-        kf_type = kalman_type.EKF6
-    elif args['ukf']:
-        kf_type = kalman_type.UKF6
-
     if args['--post-smoother'] == 'savgol':
         post_smoother = smoother_type.SAVGOL
     elif args['--post-smoother'] == 'uniform':
@@ -388,7 +234,7 @@ if __name__ == '__main__':
     if args['--noise-std']:
         noise_std = float(args['--noise-std'])
 
-    droneloc = drone_localization(kf_type, dt, post_smoother=post_smoother)
+    droneloc = drone_localization(dt, post_smoother=post_smoother)
 
     # Plot anchors
     anchors_coords = get_anchors_coords(anchors)

--- a/python_loc/droneloc.py
+++ b/python_loc/droneloc.py
@@ -321,14 +321,10 @@ class drone_localization():
         elif self.kf_type == kalman_type.UKF6:
             self.kf.update(z, loc=loc)
 
-        if self.kf.x[4] < 0:
-            self.kf.x[4] = np.abs(self.kf.x[4])
-
         if np.any(np.abs(self.kf.y) > 2):
             print("innovation is too large: ", self.kf.y)
             self.kf.x = old_x
             self.kf.P = old_P
-            return None
 
         Xk = self.kf.x
 
@@ -338,7 +334,7 @@ class drone_localization():
 
             self.x_hist.append(Xk)
             if len(self.x_hist) < hist_window:
-                return None
+                return [0.0, 0.0, 0.0]
 
             if self.post_smoother == smoother_type.SAVGOL:
                 Xk_f = savgol_filter(self.x_hist, hist_window, 5,

--- a/python_loc/droneloc.py
+++ b/python_loc/droneloc.py
@@ -40,9 +40,9 @@ class smoother_type(enum.Enum):
     UNIFORM  = 1
     GAUSSIAN = 2
 
-sigma_process = 0.125
+sigma_process = 0.225
 sigma_dist = 0.2
-sigma_vel = 0.1
+sigma_vel = 0.05
 sigma_alt = 0.02
 
 R_scale = 1

--- a/python_loc/droneloc.py
+++ b/python_loc/droneloc.py
@@ -225,12 +225,10 @@ class drone_localization():
         dt = self.get_dt(loc)
 
         self.kf.Q = Q_6(dt)
-        self.kf._dim_z = len(loc['anchors'])
         self.kf.predict(dt=dt)
 
         z = get_measurements_dist(loc)
-        self.kf.R = R
-        self.kf.update(z, hx=Hx_6_dist, loc=loc)
+        self.kf.update(z, R=R, hx=Hx_6_dist, loc=loc)
 
         if np.any(np.abs(self.kf.y) > 2):
             print("innovation DIST is too large: ", self.kf.y)
@@ -249,12 +247,10 @@ class drone_localization():
         dt = self.get_dt(alt)
 
         self.kf.Q = Q_6(dt)
-        self.kf._dim_z = 1
         self.kf.predict(dt=dt)
 
         z = get_measurements_alt(alt)
-        self.kf.R = R
-        self.kf.update(z, hx=Hx_6_alt)
+        self.kf.update(z, R=R, hx=Hx_6_alt)
 
         if np.any(np.abs(self.kf.y) > 2):
             print("innovation ALT is too large: ", self.kf.y)
@@ -275,12 +271,10 @@ class drone_localization():
         dt = self.get_dt(vel)
 
         self.kf.Q = Q_6(dt)
-        self.kf._dim_z = 3
         self.kf.predict(dt=dt)
 
         z = get_measurements_vel(vel)
-        self.kf.R = R
-        self.kf.update(z, hx=Hx_6_vel)
+        self.kf.update(z, R=R, hx=Hx_6_vel)
 
         if np.any(np.abs(self.kf.y) > 2):
             print("innovation VEL is too large: ", self.kf.y)

--- a/python_loc/location.py
+++ b/python_loc/location.py
@@ -569,7 +569,7 @@ if __name__ == '__main__':
     plot_sock = create_plot_sock()
 
     navigator.start()
-    droneloc = drone_localization(post_smoother=post_smoother)
+    droneloc = drone_localization(cfg.KALMAN_TYPE, post_smoother=post_smoother)
 
     signal.signal(signal.SIGINT, sigint_handler)
 

--- a/python_loc/location.py
+++ b/python_loc/location.py
@@ -26,7 +26,6 @@ import signal
 
 import filterpy.kalman
 from droneloc import drone_localization
-from droneloc import kalman_type
 from droneloc import smoother_type
 
 import dwm1001_ble
@@ -531,7 +530,7 @@ if __name__ == '__main__':
     plot_sock = create_plot_sock()
 
     navigator.start()
-    droneloc = drone_localization(kalman_type.EKF6, post_smoother=post_smoother)
+    droneloc = drone_localization(post_smoother=post_smoother)
 
     signal.signal(signal.SIGINT, sigint_handler)
 
@@ -547,7 +546,7 @@ if __name__ == '__main__':
         start = time.time()
 
         # Invoke localization
-        x, y, z = droneloc.kf_process(loc, nano_data)
+        x, y, z = droneloc.kf_process(loc)
 
         # Calculate update rate
         rate = avg_rate()

--- a/python_loc/location.py
+++ b/python_loc/location.py
@@ -509,55 +509,57 @@ def find_anchor_by_addr(location, addr):
 
     return None
 
-args = docopt(__doc__)
-if args['--data-source'] == 'sock':
-    DWM_DATA_SOURCE = dwm_source.SOCK
-elif args['--data-source'] == 'ble':
-    DWM_DATA_SOURCE = dwm_source.BLE
-else:
-    print("Error: incorrect --data-source param, should be 'ble' or 'sock'")
-    sys.exit(-1)
-
-avg_rate = avg_rate()
-navigator = drone_navigator(cfg.LANDING_X, cfg.LANDING_Y)
-plot_sock = create_plot_sock()
-
-navigator.start()
-droneloc = drone_localization(kalman_type.EKF6, post_smoother=post_smoother)
-
 def sigint_handler(sig, frame):
     print(' You pressed Ctrl+C! Disconnecting all devices, please wait ...')
     global should_stop, stop_efd
     should_stop = True
     stop_efd.set()
 
-signal.signal(signal.SIGINT, sigint_handler)
 
-while True:
-    loc, parrot_data, nano_data = get_dwm_location_or_parrot_data()
-    if should_stop:
-        break
-    if loc is None:
-        continue
+if __name__ == '__main__':
+    args = docopt(__doc__)
+    if args['--data-source'] == 'sock':
+        DWM_DATA_SOURCE = dwm_source.SOCK
+    elif args['--data-source'] == 'ble':
+        DWM_DATA_SOURCE = dwm_source.BLE
+    else:
+        print("Error: incorrect --data-source param, should be 'ble' or 'sock'")
+        sys.exit(-1)
 
-    parrot_alt = 0
+    avg_rate = avg_rate()
+    navigator = drone_navigator(cfg.LANDING_X, cfg.LANDING_Y)
+    plot_sock = create_plot_sock()
 
-    start = time.time()
+    navigator.start()
+    droneloc = drone_localization(kalman_type.EKF6, post_smoother=post_smoother)
 
-    # Invoke localization
-    x, y, z = droneloc.kf_process(loc, nano_data)
+    signal.signal(signal.SIGINT, sigint_handler)
 
-    # Calculate update rate
-    rate = avg_rate()
+    while True:
+        loc, parrot_data, nano_data = get_dwm_location_or_parrot_data()
+        if should_stop:
+            break
+        if loc is None:
+            continue
 
-    # PID control
-    navigator.navigate_drone(x, y)
+        parrot_alt = 0
 
-    # Send all math output to the plot
-    ts = time.time()
+        start = time.time()
 
-    send_plot_data(plot_sock, x, y, z, parrot_alt, ts, rate,
-                   len(loc['anchors']), navigator, loc)
+        # Invoke localization
+        x, y, z = droneloc.kf_process(loc, nano_data)
 
-destroy_dwm_fd()
-destroy_nano33_ble()
+        # Calculate update rate
+        rate = avg_rate()
+
+        # PID control
+        navigator.navigate_drone(x, y)
+
+        # Send all math output to the plot
+        ts = time.time()
+
+        send_plot_data(plot_sock, x, y, z, parrot_alt, ts, rate,
+                       len(loc['anchors']), navigator, loc)
+
+    destroy_dwm_fd()
+    destroy_nano33_ble()

--- a/python_loc/location.py
+++ b/python_loc/location.py
@@ -431,7 +431,7 @@ def receive_parrot_data_from_sock(sock):
     return parrot_data
 
 def is_dwm_location_reliable(loc):
-    return len(loc['anchors']) >= 3
+    return len(loc['anchors']) >= 2
 
 def print_location(loc):
     coords = loc['pos']['coords']

--- a/python_loc/location.py
+++ b/python_loc/location.py
@@ -534,13 +534,29 @@ if __name__ == '__main__':
 
     signal.signal(signal.SIGINT, sigint_handler)
 
+    # If DWM modules stop returning distances don't fuse altitude or velocity,
+    # otherwise innovation (residual) starts growing
+    without_dwm_data = 1<<32
+
     while True:
         loc, parrot_data, nano_data = get_dwm_location_or_parrot_data()
         if should_stop:
             break
+
+        if parrot_data is not None and without_dwm_data < 4:
+            without_dwm_data += 1
+
+            if 'alt' in parrot_data:
+                # Fuse altitude
+                droneloc.kf_process_alt(parrot_data)
+            elif 'vel' in parrot_data:
+                # Fuse velocity
+                droneloc.kf_process_vel(parrot_data)
+
         if loc is None:
             continue
 
+        without_dwm_data = 0
         parrot_alt = 0
 
         start = time.time()

--- a/python_loc/location.py
+++ b/python_loc/location.py
@@ -545,8 +545,8 @@ if __name__ == '__main__':
 
         start = time.time()
 
-        # Invoke localization
-        x, y, z = droneloc.kf_process(loc)
+        # Invoke distance localization
+        x, y, z = droneloc.kf_process_dist(loc)
 
         # Calculate update rate
         rate = avg_rate()

--- a/python_loc/location.py
+++ b/python_loc/location.py
@@ -38,10 +38,6 @@ from scipy.optimize import minimize
 from simple_pid import PID
 import config as cfg
 
-from scipy.signal import savgol_filter
-from scipy.ndimage import gaussian_filter1d
-from scipy.ndimage import uniform_filter1d
-
 args        = None
 dwm_fd      = None
 nano33_fd   = None
@@ -54,9 +50,6 @@ nano33_manager = None
 
 should_stop = False
 stop_efd    = eventfd.EventFD()
-
-anch_len_log = {}
-hist_len_sec = 5
 
 total_pos = 0
 total_calc = 0
@@ -77,26 +70,6 @@ pre_smoother  = None
 post_smoother = None
 
 DWM_DATA_SOURCE = dwm_source.BLE
-
-class len_log:
-    def __init__(self):
-        self.data = []
-        self.T = []
-
-    def add_to_filter(self, l, ts):
-        self.data.append(l)
-        self.T.append(ts)
-
-        if pre_smoother == smoother_type.UNIFORM and len(self.data) > moving_window:
-            self.data = list(uniform_filter1d(self.data, size=moving_window, mode="reflect"))
-        if pre_smoother == smoother_type.GAUSSIAN:
-            self.data = list(gaussian_filter1d(self.data, 6))
-
-        while (len(self.T) > 0) and (ts - self.T[0] > hist_len_sec):
-            self.data.pop(0)
-            self.T.pop(0)
-
-        return self.data[-1]
 
 #
 # Welford's online algorithm
@@ -552,17 +525,6 @@ plot_sock = create_plot_sock()
 navigator.start()
 droneloc = drone_localization(kalman_type.EKF6, post_smoother=post_smoother)
 
-def filter_dist(loc):
-    for anch in loc["anchors"]:
-        addr = anch["addr"]
-        dist = anch["dist"]["dist"]
-
-        if addr not in anch_len_log:
-            anch_len_log[addr] = len_log()
-
-        dist = anch_len_log[addr].add_to_filter(dist, loc['ts'])
-        anch["dist"]["dist"] = dist
-
 def sigint_handler(sig, frame):
     print(' You pressed Ctrl+C! Disconnecting all devices, please wait ...')
     global should_stop, stop_efd
@@ -579,8 +541,6 @@ while True:
         continue
 
     parrot_alt = 0
-
-    filter_dist(loc)
 
     start = time.time()
 


### PR DESCRIPTION
Added support of EKF in droneloc.

Command line argument --kf-type is added. It can be "ekf" or "ukf". If
not specified then ukf is used as a default. To run:

python3 droneloc.py --trajectory ../data/trajectory.txt --noise-std 200
--fuse-velocity --fuse-altitude --kf-type ekf

or

python3 droneloc.py --trajectory ../data/trajectory.txt --noise-std 200
--fuse-velocity --fuse-altitude --kf-type ukf

Signed-off-by: Aleksei Marov <alekseymmm@mail.ru>